### PR TITLE
Use `y-crdt/y-crdt` to build Rust binaries

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 env:
-  YRS_REPO: https://github.com/LSViana/y-crdt
+  YRS_REPO: https://github.com/y-crdt/y-crdt
   YRS_BRANCH: main
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Solves #74.