### PR TITLE
Fix memory leak when reading guid

### DIFF
--- a/YDotNet/Document/Doc.cs
+++ b/YDotNet/Document/Doc.cs
@@ -209,18 +209,20 @@ public class Doc : UnmanagedResource
         {
             ThrowIfDisposed();
 
-            var stringHandle = DocChannel.Guid(Handle);
+            var stringHandle = DocChannel.CollectionId(Handle);
+
+            if (stringHandle == nint.Zero)
+            {
+                return null;
+            }
+
             try
             {
-                MemoryReader.TryReadUtf8String(stringHandle, out var result);
-                return result;
+                return MemoryReader.ReadUtf8String(stringHandle);
             }
             finally
             {
-                if (stringHandle != nint.Zero)
-                {
-                    StringChannel.Destroy(stringHandle);
-                }
+                StringChannel.Destroy(stringHandle);
             }
         }
     }

--- a/YDotNet/Document/Doc.cs
+++ b/YDotNet/Document/Doc.cs
@@ -151,14 +151,14 @@ public class Doc : UnmanagedResource
         {
             ThrowIfDisposed();
 
-            var guidHandle = DocChannel.Guid(Handle);
+            var stringHandle = DocChannel.Guid(Handle);
             try
             {
-                return MemoryReader.ReadUtf8String(guidHandle);
+                return MemoryReader.ReadUtf8String(stringHandle);
             }
             finally
             {
-                StringChannel.Destroy(guidHandle);
+                StringChannel.Destroy(stringHandle);
             }
         }
     }
@@ -209,8 +209,19 @@ public class Doc : UnmanagedResource
         {
             ThrowIfDisposed();
 
-            MemoryReader.TryReadUtf8String(DocChannel.CollectionId(Handle), out var result);
-            return result;
+            var stringHandle = DocChannel.Guid(Handle);
+            try
+            {
+                MemoryReader.TryReadUtf8String(DocChannel.CollectionId(Handle), out var result);
+                return result;
+            }
+            finally
+            {
+                if (stringHandle != nint.Zero)
+                {
+                    StringChannel.Destroy(stringHandle);
+                }
+            }
         }
     }
 

--- a/YDotNet/Document/Doc.cs
+++ b/YDotNet/Document/Doc.cs
@@ -8,6 +8,7 @@ using YDotNet.Document.Types.XmlTexts;
 using YDotNet.Infrastructure;
 using YDotNet.Native.Document;
 using YDotNet.Native.Document.Events;
+using YDotNet.Native.Types;
 using Array = YDotNet.Document.Types.Arrays.Array;
 
 namespace YDotNet.Document;
@@ -150,7 +151,15 @@ public class Doc : UnmanagedResource
         {
             ThrowIfDisposed();
 
-            return MemoryReader.ReadUtf8String(DocChannel.Guid(Handle));
+            var guidHandle = DocChannel.Guid(Handle);
+            try
+            {
+                return MemoryReader.ReadUtf8String(guidHandle);
+            }
+            finally
+            {
+                StringChannel.Destroy(guidHandle);
+            }
         }
     }
 

--- a/YDotNet/Document/Doc.cs
+++ b/YDotNet/Document/Doc.cs
@@ -212,7 +212,7 @@ public class Doc : UnmanagedResource
             var stringHandle = DocChannel.Guid(Handle);
             try
             {
-                MemoryReader.TryReadUtf8String(DocChannel.CollectionId(Handle), out var result);
+                MemoryReader.TryReadUtf8String(stringHandle, out var result);
                 return result;
             }
             finally

--- a/YDotNet/Infrastructure/MemoryReader.cs
+++ b/YDotNet/Infrastructure/MemoryReader.cs
@@ -106,17 +106,4 @@ internal static class MemoryReader
         StringChannel.Destroy(handle);
         return result;
     }
-
-    internal static bool TryReadUtf8String(nint handle, out string? result)
-    {
-        if (handle == nint.Zero)
-        {
-            result = null;
-            return false;
-        }
-
-        result = ReadUtf8String(handle);
-
-        return true;
-    }
 }

--- a/YDotNet/Infrastructure/MemoryReader.cs
+++ b/YDotNet/Infrastructure/MemoryReader.cs
@@ -91,19 +91,6 @@ internal static class MemoryReader
         return Encoding.UTF8.GetString(readOnlySpan);
     }
 
-    internal static bool TryReadUtf8String(nint handle, out string? result)
-    {
-        if (handle == nint.Zero)
-        {
-            result = null;
-            return false;
-        }
-
-        result = ReadUtf8String(handle);
-
-        return true;
-    }
-
     public static byte[] ReadAndDestroyBytes(nint handle, uint length)
     {
         var data = ReadBytes(handle, length);
@@ -118,5 +105,18 @@ internal static class MemoryReader
 
         StringChannel.Destroy(handle);
         return result;
+    }
+
+    internal static bool TryReadUtf8String(nint handle, out string? result)
+    {
+        if (handle == nint.Zero)
+        {
+            result = null;
+            return false;
+        }
+
+        result = ReadUtf8String(handle);
+
+        return true;
     }
 }


### PR DESCRIPTION
According to the lib.rs, we need to destroy the strings.

https://github.com/y-crdt/y-crdt/blob/main/yffi/src/lib.rs#L425

I think we should also convert the guid to from string to guid. It is a weird API design.