### PR TITLE
chore: bump library version to 0.2.13 to release the MacOS ARM library

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <Version>0.2.12</Version>
+    <Version>0.2.13</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">


### PR DESCRIPTION
chore: bump library version to 0.2.13 to release the MacOS ARM library.

I believe that to make the actual release we need to set up a `v0.2.13` tag, which I am not sure I am able to since I don't have any permissions in the repository.