### PR TITLE
Fix exception when converting documents containing maps to JSON

### DIFF
--- a/Tests/YDotNet.Tests.Unit/Extensions/Conversion.cs
+++ b/Tests/YDotNet.Tests.Unit/Extensions/Conversion.cs
@@ -43,6 +43,34 @@ internal class Conversion
     }
 
     [Test]
+    public void CanParseMapsToObject()
+    {
+        // Arrange
+        var doc = new Doc();
+        var items = doc.Array("items");
+
+        using (var transaction = doc.WriteTransaction())
+        {
+            var map = Input.Map(new Dictionary<string, Input>()
+            {
+                ["value"] = Input.String("Hello YDotNet"),
+            });
+            items.InsertRange(transaction, 0, map);
+        }
+
+        using (var transaction = doc.ReadTransaction())
+        {
+            var map = items.Get(transaction, 0);
+            
+            // Act
+            var parsed = map.To<Expected>(transaction);
+            
+            // Assert
+            Assert.That(parsed.Value, Is.EqualTo("Hello YDotNet"));
+        }
+    }
+
+    [Test]
     public void ConvertToJson()
     {
         // Arrange

--- a/YDotNet.Extensions/YDotNetExtensions.cs
+++ b/YDotNet.Extensions/YDotNetExtensions.cs
@@ -91,14 +91,14 @@ public static class YDotNetExtensions
 
         static void WriteMap(Map map, Utf8JsonWriter jsonWriter, Transaction transaction)
         {
-            jsonWriter.WriteStartArray();
+            jsonWriter.WriteStartObject();
 
             foreach (var property in map.Iterate(transaction))
             {
                 WriteProperty(property.Key, property.Value, jsonWriter, transaction);
             }
 
-            jsonWriter.WriteEndArray();
+            jsonWriter.WriteEndObject();
         }
 
         static void WriteArray(Array array, Utf8JsonWriter jsonWriter, Transaction transaction)


### PR DESCRIPTION
Previously, converting a document containing a `Map` to JSON would throw an exception during JSON generation due to a copy-paste bug. Fix the bug and add a test for the scenario.

Fixes #86 